### PR TITLE
Prompt for WordPress version to install - note, no version/error checkin...

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -37,6 +37,11 @@ var VVVGenerator = yeoman.generators.Base.extend({
         default: 'genius.dev'
       },
       {
+        name:    'wordpressVersion',
+        message: 'What version of WordPress would you like to install?',
+        default: 'latest'
+      },
+      {
         name:    'liveUrl',
         message: 'What is the live domian? (genius.com - blank if none)'
       },
@@ -58,6 +63,7 @@ var VVVGenerator = yeoman.generators.Base.extend({
     this.prompt(prompts, function (props) {
       this.site = {
         name:      props.siteName,
+        wpversion: props.wordpressVersion,
         url:       props.siteUrl,
         liveUrl:   props.liveUrl,
         multisite: props.multisite,

--- a/app/templates/_site-vars.sh
+++ b/app/templates/_site-vars.sh
@@ -24,3 +24,6 @@ live_domain='<%= site.liveUrl %>'
 
 # This sets up the name of the DB and the user and password for the DB.
 siteId='<%= site.id %>'
+
+# Set the version of WordPress to install
+wordpressVersion='<%= site.wpversion %>'

--- a/app/templates/vvv-init.sh
+++ b/app/templates/vvv-init.sh
@@ -57,7 +57,7 @@ if [[ ! -d htdocs ]]
 	fi
 	# Move into htdocs to run 'wp' commands.
 	cd htdocs
-	wp --allow-root core download
+	wp --allow-root core download --version="$wordpressVersion"
 	echo "$constants" | wp --allow-root core config --dbname="$siteId" --dbuser="wordpress" --dbpass="wordpress" --extra-php
 	#Install as needed
 	if ! $(wp --allow-root core is-installed)


### PR DESCRIPTION
This adds a prompt for WordPress version during install, defaults to 'latest' - tested; no checking if version actually exists
