### PR TITLE
Make correct sites folder for static links

### DIFF
--- a/app/templates/vvv-init.sh
+++ b/app/templates/vvv-init.sh
@@ -5,7 +5,7 @@ echo "Commencing $site_name Site Setup"
 # Save a site referece where we can get to it.
  if [[ ! -d /var/sites ]]
  	then
- 	mkdir sites
+ 	mkdir /var/sites
  fi
  ln -s $PWD /var/sites/$siteId
 


### PR DESCRIPTION
I don't think the sites folder is created correctly if missing, my provision had an error message: http://cl.ly/image/1a1O3Z3u0z22 - this should fix, untested
