### PR TITLE
Set WP constants via vvv JSON file.

### DIFF
--- a/templates/_wp-constants
+++ b/templates/_wp-constants
@@ -1,10 +1,32 @@
-/* Debug */
-define( 'WP_DEBUG', true );
-define( 'WP_DEBUG_DISPLAY', true );
-define( 'WP_DEBUG_LOG', false );
-define( 'SCRIPT_DEBUG', true );
-define( 'SAVEQUERIES', true );
-define( 'JETPACK_DEV_DEBUG', true );
-
 /*Caching*/
 define( 'WP_CACHE_KEY_SALT', '<%= site.id %>' );
+
+<% if (wordpress.constants) {
+%>/* Constants */
+<% _.each(wordpress.constants, function(value, key, field){
+        if(!_.contains([true,false],value)){
+            value = "'" + value + "'";
+        }
+        %>define( '<%= key %>', <%= value %> );
+<%  })
+} %>
+
+/* Debug Defaults*/
+if( !defined('WP_DEBUG') ) {
+    define( 'WP_DEBUG', true );
+}
+if( !defined('WP_DEBUG_DISPLAY') ) {
+    define( 'WP_DEBUG_DISPLAY', true );
+}
+if( !defined('WP_DEBUG_LOG') ) {
+    define( 'WP_DEBUG_LOG', false );
+}
+if( !defined('SCRIPT_DEBUG') ) {
+    define( 'SCRIPT_DEBUG', true );
+}
+if( !defined('SAVEQUERIES') ) {
+    define( 'SAVEQUERIES', true );
+}
+if( !defined('JETPACK_DEV_DEBUG') ) {
+    define( 'JETPACK_DEV_DEBUG', true );
+}


### PR DESCRIPTION
Adds the ability to set the WP constants through the json file and fixes issue #30

Safely handles boolean or text value configurations.
