### PR TITLE
Remove check for www/vvv-hosts file

### DIFF
--- a/lib/base-methods/vagrant.js
+++ b/lib/base-methods/vagrant.js
@@ -127,7 +127,6 @@ function _isVVVDir( dir ) {
 	try {
 		fs.lstatSync( path.join( dir, 'Vagrantfile' ) );
 		fs.lstatSync( path.join( dir, 'www' ) );
-		fs.lstatSync( path.join( dir, 'www', 'vvv-hosts' ) );
 		return true;
 	} catch( e ) {
 		return false;


### PR DESCRIPTION
Allows the check which validates that a directory is a VVV directory to
pass even if this file is not in the expected place.

Addresses #57.